### PR TITLE
Add .clang-tidy for local linting

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,12 @@
+Checks:
+  *,
+  -altera*,
+  -llvm*,
+  -fuchsia-default-arguments-*,
+  -bugprone-easily-swappable-parameters,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -modernize-use-trailing-return-type,
+  -readability-magic-numbers,
+CheckOptions:
+  - { key: hicpp-signed-bitwise.IgnorePositiveIntegerLiterals, value: 1 }
+  - { key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic, value: 1 }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,7 +8,6 @@ Checks:
   -modernize-use-trailing-return-type,
   -readability-magic-numbers,
 CheckOptions:
-  - { key: hicpp-signed-bitwise.IgnorePositiveIntegerLiterals, value: 1 }
   # This check applies to both classes and structs, which means POD types are
   # flagged. POD types generally have all members public, so this option
   # disables the check for them.

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,4 +9,7 @@ Checks:
   -readability-magic-numbers,
 CheckOptions:
   - { key: hicpp-signed-bitwise.IgnorePositiveIntegerLiterals, value: 1 }
+  # This check applies to both classes and structs, which means POD types are
+  # flagged. POD types generally have all members public, so this option
+  # disables the check for them.
   - { key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic, value: 1 }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,9 @@
 Checks:
+  # Enable all options by default so any new checks added in the future will be
+  # automatically enabled.
   *,
+  # Altera and LLVM checks seem to be intended for internal use. LLVM in
+  # particular wants to ensure everything is in the LLVM namespace.
   -altera*,
   -llvm*,
   -fuchsia-default-arguments-*,


### PR DESCRIPTION
I've included an initial set of checks that might be too picky. We can
selectively disable more in the future.