### PR TITLE
Use .clang-tidy and .clang-format for cpp-linter

### DIFF
--- a/.github/workflows/cpp_linter.yaml
+++ b/.github/workflows/cpp_linter.yaml
@@ -18,7 +18,7 @@ jobs:
           # An empty string means "use the .clang-tidy file"
           tidy-checks: ""
           lines-changed-only: false
-          files-changed-only: false
+          files-changed-only: true
 
       - name: Fail Fast?!
         if: steps.linter.outputs.checks-failed > 0

--- a/.github/workflows/cpp_linter.yaml
+++ b/.github/workflows/cpp_linter.yaml
@@ -14,9 +14,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          style: llvm
+          style: file
+          # An empty string means "use the .clang-tidy file"
+          tidy-checks: ""
           lines-changed-only: false
-          files-changed-only: true
+          files-changed-only: false
 
       - name: Fail Fast?!
         if: steps.linter.outputs.checks-failed > 0


### PR DESCRIPTION
Fixes #12.