### PR TITLE
Small changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 /build/
 /cmake-build-*/
+/compile_commands.json

--- a/src/parallel/parallel.cpp
+++ b/src/parallel/parallel.cpp
@@ -229,11 +229,10 @@ ParallelRobinHoodHashTable::find_next_index_lock(ThreadManager &manager,
             // This is first, because equality on an empty bucket is not well defined.
             distance_key = offset;
             return {real_index, false};
-        } else if (offset < distance_key) { // This means that bkt belongs to a nearer home
+        } else if (offset < distance_key) {
             distance_key = offset;
             return {real_index, false};
-            // If found
-        } else if (pair.key == key) {
+        } else if (pair.key == key) { // If found
             return {real_index, true};
         }
     }

--- a/src/parallel/parallel.cpp
+++ b/src/parallel/parallel.cpp
@@ -202,7 +202,8 @@ ParallelRobinHoodHashTable::remove_thread_lock_manager()
 }
 
 /// @brief  Get real bucket index.
-size_t static get_real_index(const size_t home, const size_t offset, const size_t capacity)
+static size_t
+get_real_index(const size_t home, const size_t offset, const size_t capacity)
 {
     LOG_TRACE("Enter");
     return (home + offset) % capacity;

--- a/src/parallel/parallel.cpp
+++ b/src/parallel/parallel.cpp
@@ -280,14 +280,14 @@ ParallelRobinHoodHashTable::distance_zero_insert(KeyType key,
     KeyValue blank_kv;
     KeyValue new_kv = {key, value};
     // Attempt fast-path insertion if the key-value pair is empty
-    if (this->buckets_[dist_zero_slot].key_value.load() == blank_kv) {
+    if (this->buckets_[dist_zero_slot].load() == blank_kv) {
         if (compare_and_set_key_val(dist_zero_slot, blank_kv, new_kv)) {
             return InsertStatus::inserted_at_home;
         };
     }
     // Attempt fast-path update if key matches our key
-    if (this->buckets_[dist_zero_slot].key_value.load().key == key) {
-        KeyValue old_kv = {key, this->buckets_[dist_zero_slot].key_value.load().value};
+    if (this->buckets_[dist_zero_slot].load().key == key) {
+        KeyValue old_kv = {key, this->buckets_[dist_zero_slot].load().value};
         if (compare_and_set_key_val(dist_zero_slot, old_kv, new_kv)) {
             return InsertStatus::updated_at_home;
         };

--- a/src/parallel/parallel.cpp
+++ b/src/parallel/parallel.cpp
@@ -3,8 +3,6 @@
 #include "parallel.hpp"
 
 constexpr unsigned indices_per_segment = 16;
-constexpr KeyType empty_bucket_key = static_cast<KeyType>(-1);
-constexpr KeyType locked_bucket_key = static_cast<KeyType>(-2);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// SEGMENT LOCK
@@ -226,7 +224,7 @@ ParallelRobinHoodHashTable::find_next_index_lock(ThreadManager &manager,
         const size_t home = hash(pair.key);
         const size_t offset = real_index - home;
 
-        if (pair.key == empty_bucket_key) {
+        if (pair.key == bucket_empty_key) {
             // This is first, because equality on an empty bucket is not well defined.
             distance_key = offset;
             return {real_index, false};

--- a/src/parallel/parallel.cpp
+++ b/src/parallel/parallel.cpp
@@ -10,7 +10,7 @@ constexpr KeyType locked_bucket_key = static_cast<KeyType>(-2);
 /// SEGMENT LOCK
 ////////////////////////////////////////////////////////////////////////////////
 
-unsigned
+SegmentLock::Version
 SegmentLock::get_version()
 {
     return this->version_;
@@ -117,7 +117,7 @@ ThreadManager::speculate_index(size_t index)
     //                                  2. Increment lock count
     // 2. Get lock count
     // 3. Search for key...             3. Modify hash table...
-    size_t segment_lock_version = segment_lock.get_version();
+    SegmentLock::Version segment_lock_version = segment_lock.get_version();
     bool segment_locked = segment_lock.is_locked();
     if (!segment_locked) {
         this->segment_lock_index_and_version_.emplace_back(segment_index, segment_lock_version);
@@ -130,7 +130,7 @@ bool
 ThreadManager::finish_speculate()
 {
     for (auto &[seg_idx, old_seg_version] : this->segment_lock_index_and_version_) {
-        size_t new_seg_version = this->hash_table_->segment_locks_[seg_idx].get_version();
+        SegmentLock::Version new_seg_version = this->hash_table_->segment_locks_[seg_idx].get_version();
         if (old_seg_version != new_seg_version) {
             this->segment_lock_index_and_version_.clear();
             this->locked_segments_.clear();

--- a/src/parallel/parallel.hpp
+++ b/src/parallel/parallel.hpp
@@ -68,11 +68,15 @@ private:
 /// HELPER CLASSES
 ////////////////////////////////////////////////////////////////////////////////
 
+static constexpr KeyType bucket_empty_key = static_cast<KeyType>(-1);
+static constexpr KeyType bucket_locked_key = static_cast<KeyType>(-2);
+
 /// We are assuming this will be packed into 8 (or 16... if we've changed the
 /// size of the KeyType/ValueType to int64_t) bytes so that we can atomically
 /// update both.
 struct KeyValue {
-    KeyType key = 0;
+
+    KeyType key = bucket_empty_key;
     ValueType value = 0;
 
     constexpr bool operator==(const KeyValue &) const = default;

--- a/src/parallel/parallel.hpp
+++ b/src/parallel/parallel.hpp
@@ -28,15 +28,16 @@ enum class InsertStatus {
     not_inserted,
 };
 
-/// We want the AtomicCounter to allow for overflow. This means that we should
-/// not use ordering operators to allow for overflow. This also makes the
-/// assumption that the AtomicCounter will not be incremented until it overflows
-/// and reaches the formerly held value again.
-using AtomicCounter = std::atomic<unsigned>;
-
 class SegmentLock {
 public:
-    unsigned
+    /// We want the AtomicCounter to allow for overflow. This means that we should
+    /// not use ordering operators to allow for overflow. This also makes the
+    /// assumption that the AtomicCounter will not be incremented until it overflows
+    /// and reaches the formerly held value again.
+    using Version = size_t;
+    using AtomicVersion = std::atomic<Version>;
+
+    Version
     get_version();
 
     bool
@@ -59,7 +60,7 @@ private:
     //      function.
     // N.B. This needs to be atomic since it can be read from multiple threads
     //      via get_version() while its being modified by one thread.
-    AtomicCounter version_{0};
+    AtomicVersion version_{0};
     unsigned locked_count_{0};
 };
 

--- a/src/parallel/parallel.hpp
+++ b/src/parallel/parallel.hpp
@@ -116,7 +116,7 @@ public:
 private:
     class ParallelRobinHoodHashTable *const hash_table_;
     std::vector<size_t> locked_segments_;
-    std::vector<std::pair<size_t, unsigned>> segment_lock_index_and_version_;
+    std::vector<std::pair<size_t, SegmentLock::Version>> segment_lock_index_and_version_;
 };
 
 size_t

--- a/src/parallel/parallel.hpp
+++ b/src/parallel/parallel.hpp
@@ -61,6 +61,8 @@ private:
     // N.B. This needs to be atomic since it can be read from multiple threads
     //      via get_version() while its being modified by one thread.
     AtomicVersion version_{0};
+    // N.B. We use unsigned since locked_count_ is bounded by the number of
+    //      elements within a segment, assuming we only lock once per element.
     unsigned locked_count_{0};
 };
 


### PR DESCRIPTION
* Rename SegmentLock::counter_ to version_
* Add SegmentLock::locked_count_ to enable unlocking a symmetric number of times
* Remove ParallelBucket::offset and inline KeyValue
* Make get_segment_index a free function
* Implement find_next_index_lock
* Use consistent type (unsigned) for SegmentLock::version_

TODO:
- [ ] Add Griffin's changes
